### PR TITLE
NO_SSLv2 became an illegal option in 

### DIFF
--- a/stunnel/map.jinja
+++ b/stunnel/map.jinja
@@ -5,11 +5,12 @@
 {% import_yaml "stunnel/os_family_map.yaml" as os_family_map %}
 {% import_yaml "stunnel/os_codename_map.yaml" as os_codename_map %}
 {% import_yaml "stunnel/service_defaults.yaml" as service_defaults %}
+{% import_yaml "stunnel/service_os_codename_map.yaml" as service_os_codename_map %}
 
 {# get the settings for the os_family grain #}
 {% set osfam = salt['grains.filter_by'](os_family_map) or {} %}
 
-{# get the settings for the oscodename grain, os_family data will override oscodename data #}
+{# get the settings for the oscodename grain #}
 {% set oscode = salt['grains.filter_by'](os_codename_map, grain='oscodename', merge=osfam) or {} %}
 
 {# merge the os family/os codename specific data over the defaults #}
@@ -20,3 +21,6 @@
 
 {# merge the actual stunnel pillar into the above combined dict #}
 {% set stunnel = salt['pillar.get']('stunnel', default=lookup, merge=True) %}
+
+{# update service defaults #}
+{% do service_defaults.update(salt['grains.filter_by'](service_os_codename_map, grain='oscodename') or {}) %}

--- a/stunnel/service_defaults.yaml
+++ b/stunnel/service_defaults.yaml
@@ -13,7 +13,6 @@ ciphers: 'EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECDH+aRSA+S
 sslVersion: all
 # Exclude known (becoming) insecure SSL/TLS versions
 options:
-  - NO_SSLv2
   - NO_SSLv3
   - NO_TLSv1
   - cipher_server_preference

--- a/stunnel/service_os_codename_map.yaml
+++ b/stunnel/service_os_codename_map.yaml
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+
+# Uses < 5.06
+trusty: &still_supporting_SSLv2
+  options:
+    - NO_SSLv2
+    - NO_SSLv3
+    - NO_TLSv1
+    - cipher_server_preference


### PR DESCRIPTION
Fixes the following error:

```
"options = NO_SSLv2": Illegal TLS option
```