### PR TITLE
Adding option to disable automatic certificates configuration generation

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -14,9 +14,16 @@ stunnel:
     log_dir: /var/log/stunnel
     pid: /var/run/stunnel.pid
     debug: notice
+    # Set certificates_auto_config to false if you do not want to use
+    # the automated certificates configuration from this formula.
+    # Also, this will unset verifyChain and verifyPeer.
+    # You will then be able to manage those settings manually in the service
+    # section
+    certificates_auto_config: true
     service_defaults:
       # Use this to override service_defaults.yaml
-      # The presence of these files per service is MANDATORY.
+      # The presence of these files per service is MANDATORY unless
+      # you have set certificates_auto_config to false.
       # Managing these files is currently out of scope of this formula.
       # (Have a look at map.jinja to get your OS'es paths.)
       cert: /etc/stunnel/tls/${service_name}.crt

--- a/stunnel/macro.jinja
+++ b/stunnel/macro.jinja
@@ -6,11 +6,16 @@
 
 {%- macro service_segment(name) -%}
 {%  set service = service_defaults.copy() -%}
-{%  do service.update({
-      'CAfile': stunnel.conf_dir+'/tls/'+name+'.ca',
-      'cert': stunnel.conf_dir+'/tls/'+name+'.crt',
-      'key': stunnel.conf_dir+'/tls/'+name+'.key',
-}) -%}
+{%- if stunnel.certificates_auto_config -%}
+{%    do service.update({
+        'CAfile': stunnel.conf_dir+'/tls/'+name+'.ca',
+        'cert': stunnel.conf_dir+'/tls/'+name+'.crt',
+        'key': stunnel.conf_dir+'/tls/'+name+'.key',
+      }) -%}
+{%- else -%}
+{%-   do service.pop('verifyPeer') -%}
+{%-   do service.pop('verifyChain') -%}
+{%- endif -%}
 {%  do service.update(salt['pillar.get']('stunnel:config:services:'+name, {})) -%}
 [ {{ name }} ]
 {%  for key in service.keys() | sort -%}

--- a/stunnel/os_family_map.yaml
+++ b/stunnel/os_family_map.yaml
@@ -12,6 +12,7 @@ Debian:
   default: /etc/default/stunnel4
   pid_dir: /var/run/stunnel4
   use_chroot: true
+  certificates_auto_config: true
 
 FreeBSD:
   package: stunnel
@@ -25,3 +26,4 @@ FreeBSD:
   default: None
   pid_dir: /var/run
   use_chroot: false
+  certificates_auto_config: true


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [x] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

https://github.com/saltstack-formulas/stunnel-formula/issues/6


### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->
Adding a new option in stunnel:lookup called enable_certificates which can make certificates configuration generation disabled when the service is to be used as a client to another instance of stunnel. The default value is set to true as to not change the standard behavior of the formula


### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

```
stunnel:
  lookup:
    enable_certificates: false
  config:
    services:
      graphite-server:
        client: 'no'
        accept: '12003'
        connect: '127.0.0.1:2003'
        debug: notice
        checkHost: myhostname
        checkIP: 192.168.0.1
      graphite-client:
        client: 'yes'
        accept: '127.0.0.1:2003'
        connect: '127.0.0.1:12003'
        verifyChain: 'yes'
        verifyPeer: 'yes'
```


### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->


### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


